### PR TITLE
fix: fix documentation issues and add English translation for navigation menu

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -49,8 +49,11 @@ export default defineConfig({
           items: [
             // Each item here is one entry in the navigation menu.
             {
-              label: "Inicio rápido",
+              label: "Getting Started",
               link: "/introduction/introduction/",
+              translations: {
+                es: "Inicio rápido",
+          },
             },
           ],
           translations: {

--- a/docs/src/content/docs/es/guides/horizontallist.mdx
+++ b/docs/src/content/docs/es/guides/horizontallist.mdx
@@ -12,7 +12,7 @@ En este ejemplo vamos usar **Vue Fluid DnD** para ordernar una lista horizontal.
 Primero, vamos a crear una lista de números y vamos añadir el propiedad `direction` con valor igual `horizontal`:
 
 export const listOfNumbers = `<script setup lang="ts">
-  const list = ref(1, 2, 3, 4, 5]);
+  const list = ref([1, 2, 3, 4, 5]);
   const { parent } = useDragAndDrop(list, { direction: "horizontal" });
 </script>`;
 

--- a/docs/src/content/docs/es/introduction/introduction.mdx
+++ b/docs/src/content/docs/es/introduction/introduction.mdx
@@ -46,7 +46,7 @@ Importa **composable** (`useDragAndDrop`):
 
 export const compositionApiCode = `
 <script>
-  import { useDragAndDrop } from 'vue3-fluid-dnd';
+  import { useDragAndDrop } from 'vue-fluid-dnd';
 </script>`;
 
 <Code code={compositionApiCode} lang="vue" />

--- a/docs/src/content/docs/guides/horizontallist.mdx
+++ b/docs/src/content/docs/guides/horizontallist.mdx
@@ -12,7 +12,7 @@ In this example we'll use **Vue Fluid DnD** for sorting a horizontal list.
 First, we're going to create a list of numbers and adding the property `direction` with value `horizontal`:
 
 export const listOfNumbers = `<script setup lang="ts">
-    const list = ref(1, 2, 3, 4, 5]);
+    const list = ref([1, 2, 3, 4, 5]);
     const { parent } = useDragAndDrop(list, { direction: "horizontal" });
 </script>`;
 

--- a/docs/src/content/docs/introduction/introduction.mdx
+++ b/docs/src/content/docs/introduction/introduction.mdx
@@ -46,7 +46,7 @@ Import **composable** (`useDragAndDrop`):
 
 export const compositionApiCode = `
 <script>
-  import { useDragAndDrop } from 'vue3-fluid-dnd';
+  import { useDragAndDrop } from 'vue-fluid-dnd';
 </script>`;
 
 <Code code={compositionApiCode} lang="vue" />


### PR DESCRIPTION
In this PR, I have made some minor fixes to the documentation and added an English translation for the navigation menu. The changes are as follows:

1. Fix syntax error in the listOfNumbers variable.
2. Fix import statement for `useDragAndDrop` from `vue3-fluid-dnd` to `vue-fluid-dnd`.
3. Add English translation for the "Getting Started" section.

I hope these changes will help improve the accuracy and readability of the documentation. 